### PR TITLE
Add QRcode generation option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react-dom": "^18.0.8",
         "axios": "^1.1.3",
         "moment": "^2.29.4",
+        "qr-code-styling": "^1.6.0-rc.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-responsive": "^9.0.2",
@@ -6061,6 +6062,19 @@
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
       }
+    },
+    "node_modules/qr-code-styling": {
+      "version": "1.6.0-rc.1",
+      "resolved": "https://registry.npmjs.org/qr-code-styling/-/qr-code-styling-1.6.0-rc.1.tgz",
+      "integrity": "sha512-ModRIiW6oUnsP18QzrRYZSc/CFKFKIdj7pUs57AEVH20ajlglRpN3HukjHk0UbNMTlKGuaYl7Gt6/O5Gg2NU2Q==",
+      "dependencies": {
+        "qrcode-generator": "^1.4.3"
+      }
+    },
+    "node_modules/qrcode-generator": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.4.4.tgz",
+      "integrity": "sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react-dom": "^18.0.8",
     "axios": "^1.1.3",
     "moment": "^2.29.4",
+    "qr-code-styling": "^1.6.0-rc.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-responsive": "^9.0.2",

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -214,7 +214,6 @@ function SearchResultsList(props: {
 
 export default function Search() {
   const api = new ControlApi();
-  
   const systems = useIndexedSystems();
   const serverState = useServerStateStore();
   const ws = useWs();

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -28,12 +28,39 @@ import CircularProgress from "@mui/material/CircularProgress";
 import Dialog from "@mui/material/Dialog";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import ShortcutIcon from "@mui/icons-material/Shortcut";
+import QrCode2Icon from "@mui/icons-material/QrCode2"
 import {SingleShortcut} from "./Shortcuts";
 import SyncIcon from "@mui/icons-material/Sync";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
 import TapAndPlayIcon from '@mui/icons-material/TapAndPlay';
+import { getApiEndpoint } from '../lib/api';
+import QRCodeStyling from 'qr-code-styling';
+
+function downloadQrCode(options: {
+  path: string;
+  name: string;
+}) {
+  const { path, name } = options;
+  const data = `${getApiEndpoint()}/l/${btoa(path).replace(/[=]+$/, '')}`;
+  const qr = new QRCodeStyling({
+    data,
+    type: 'canvas',
+    width: 1024,
+    height: 1024,
+  });
+  return qr._canvasDrawingPromise.then(() => {
+    qr._canvas?.toBlob((blob) => {
+      if (!blob) return;
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${name}.png`;
+      a.click();
+    });
+  });
+}
 
 function SearchResultsList(props: {
   results?: SearchResults;
@@ -159,6 +186,17 @@ function SearchResultsList(props: {
               </Button>
             ) : null}
             <Button
+              variant="outlined"
+              sx={{mt: 1}}
+              startIcon={<QrCode2Icon/>}
+              onClick={() => props.selectedGame && downloadQrCode({
+                path: props.selectedGame.path,
+                name: props.selectedGame.name,
+              })}
+            >
+              Create QRCode
+            </Button>
+            <Button
               sx={{mt: 1}}
               onClick={() => {
                 setGameInfoOpen(false);
@@ -176,6 +214,7 @@ function SearchResultsList(props: {
 
 export default function Search() {
   const api = new ControlApi();
+  
   const systems = useIndexedSystems();
   const serverState = useServerStateStore();
   const ws = useWs();

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -194,7 +194,7 @@ function SearchResultsList(props: {
                 name: props.selectedGame.name,
               })}
             >
-              Create QRCode
+              Create QR-Code
             </Button>
             <Button
               sx={{mt: 1}}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -49,6 +49,10 @@ function downloadQrCode(options: {
     type: 'canvas',
     width: 1024,
     height: 1024,
+    qrOptions: {
+      errorCorrectionLevel: 'L',
+      mode: 'Byte',
+    },
   });
   return qr._canvasDrawingPromise.then(() => {
     qr._canvas?.toBlob((blob) => {


### PR DESCRIPTION
This PR add a new button under the Launch ( or NFC write ) button to download a QR code that points to the game api launcher.

<img width="724" alt="image" src="https://github.com/wizzomafizzo/mrext-client/assets/1194048/73934d05-1560-43ec-9f52-fcff002496fc">

Then it prompts for saving:

<img width="513" alt="image" src="https://github.com/wizzomafizzo/mrext-client/assets/1194048/f7a3369d-be55-4606-a8ff-58470a913318">

The output qrcode for now is very basic

![image](https://github.com/wizzomafizzo/mrext-client/assets/1194048/cd0836e5-ec4f-4d36-9584-7d31a8badd31)

But it can be improved a bit with a log and maybe some color/style.

