### PR TITLE
perf(): Improve performance of item lists

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -570,6 +570,11 @@ export function Menu() {
   const [sort, setSort] = useState<Sort>(Sort.NameAsc);
 
   const listMenuFolder = useListMenuFolder(currentPath);
+  const [sortedItems, setSortedItems] = useState<MEMenuItem[]>(listMenuFolder.data?.items || []);
+
+  useLayoutEffect(() => {
+    setSortedItems(sortItems(listMenuFolder.data?.items, sort, currentPath));
+  }, [sort, currentPath, listMenuFolder.data?.items]);
 
   const icon = (item: MEMenuItem) => {
     switch (item.type) {
@@ -580,34 +585,6 @@ export function Menu() {
       default:
         return <VideogameAssetIcon/>;
     }
-  };
-
-  const sortItems = (items: MEMenuItem[] | undefined) => {
-    if (!items) {
-      return [];
-    }
-
-    const sorted = [...items];
-
-    switch (sort) {
-      case Sort.NameAsc:
-        sorted.sort((a, b) => a.name.localeCompare(b.name));
-        break;
-      case Sort.NameDesc:
-        sorted.sort((a, b) => b.name.localeCompare(a.name));
-        break;
-      case Sort.DateAsc:
-        sorted.sort((a, b) => moment(a.modified).diff(moment(b.modified)));
-        break;
-      case Sort.DateDesc:
-        sorted.sort((a, b) => moment(b.modified).diff(moment(a.modified)));
-        break;
-    }
-
-    const folders = sorted.filter((item) => item.type === "folder");
-    const files = sorted.filter((item) => item.type !== "folder");
-
-    return [...folders, ...files];
   };
 
   const resetScroll = () => {
@@ -673,7 +650,7 @@ export function Menu() {
                 <ListItemText primary="Go back"/>
               </ListItemButton>
             ) : null}
-            {sortItems(listMenuFolder.data?.items).map((item) => (
+            {sortedItems.map((item) => (
               <ListItem
                 disablePadding
                 key={item.path}
@@ -722,13 +699,13 @@ export function Menu() {
 export function GamesMenu() {
   const api = new ControlApi();
 
-  const [currentPath, setCurrentPath] = useState<string>("");
-  const [sort, setSort] = useState<Sort>(Sort.NameAsc);
+
   const [openShortcut, setOpenShortcut] = React.useState(false);
   const [selectedPath, setSelectedPath] = React.useState("");
 
+  const [currentPath, setCurrentPath] = useState<string>("");
+  const [sort, setSort] = useState<Sort>(Sort.NameAsc);
   const listGamesMenu = useListGamesFolder(currentPath);
-
   const [sortedItems, setSortedItems] = useState<MEMenuItem[]>(listGamesMenu.data?.items || [])
 
   useLayoutEffect(() => {


### PR DESCRIPTION
This is an experimental PR where i try to fix what i think are performance in the long item list.
I don't have a plan, so i m kind of testing and measuring performance changes.

Reviewing with the white space hidden makes things clearer
https://github.com/wizzomafizzo/mrext-client/pull/3/files?diff=unified&w=1

Opening the arcade list, this branch:

<img width="589" alt="image" src="https://github.com/wizzomafizzo/mrext-client/assets/1194048/25f4857c-6571-42a6-83de-2ca7c8fdf188">


Opening the arcade list in the main branch:

<img width="585" alt="image" src="https://github.com/wizzomafizzo/mrext-client/assets/1194048/4001f8d1-fb50-4430-a439-c01233b5559d">
