### PR TITLE
Add remote mouse support to Control page

### DIFF
--- a/src/components/Control.tsx
+++ b/src/components/Control.tsx
@@ -11,6 +11,7 @@ import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import BluetoothIcon from "@mui/icons-material/Bluetooth";
 import AddAPhotoIcon from "@mui/icons-material/AddAPhoto";
 import KeyboardIcon from "@mui/icons-material/Keyboard";
+import MouseIcon from "@mui/icons-material/Mouse";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -22,6 +23,7 @@ import Keyboard from "react-simple-keyboard";
 import "react-simple-keyboard/build/css/index.css";
 import { Dialog } from "@mui/material";
 import useWs from "./WebSocket";
+import MousePad from "./MousePad";
 import Stack from "@mui/material/Stack";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
@@ -166,6 +168,7 @@ export default function Control() {
   const [keyboardLayout, setKeyboardLayout] = React.useState("default");
   const [keyboardOpen, setKeyboardOpen] = React.useState(false);
   const [numpadOpen, setNumpadOpen] = React.useState(false);
+  const [mouseOpen, setMouseOpen] = React.useState(false);
   const [resetOpen, setResetOpen] = React.useState(false);
 
   const ws = useWs();
@@ -390,7 +393,7 @@ export default function Control() {
       </Grid>
 
       <Grid container spacing={2} sx={{ mt: 3 }}>
-        <Grid item xs={12}>
+        <Grid item xs={6}>
           <Button
             variant="outlined"
             sx={{ width: "100%" }}
@@ -400,6 +403,18 @@ export default function Control() {
             startIcon={<KeyboardIcon />}
           >
             Keyboard
+          </Button>
+        </Grid>
+        <Grid item xs={6}>
+          <Button
+            variant="outlined"
+            sx={{ width: "100%" }}
+            onClick={() => {
+              setMouseOpen(true);
+            }}
+            startIcon={<MouseIcon />}
+          >
+            Mouse
           </Button>
         </Grid>
 
@@ -525,6 +540,12 @@ export default function Control() {
           </Button>
         </Grid>
       </Grid>
+
+      <MousePad
+        open={mouseOpen}
+        onClose={() => setMouseOpen(false)}
+        sendMessage={ws.sendMessage}
+      />
 
       <Dialog open={resetOpen} onClose={() => setResetOpen(false)}>
         <DialogContent>

--- a/src/components/MousePad.tsx
+++ b/src/components/MousePad.tsx
@@ -308,6 +308,13 @@ export default function MousePad(props: MousePadProps) {
     movedRef.current = 0;
     downTimeRef.current = e.timeStamp;
 
+    // cancel any pending single-click so this press can still complete a
+    // double-tap instead of the deferred click firing mid-press
+    if (clickTimerRef.current !== null) {
+      window.clearTimeout(clickTimerRef.current);
+      clickTimerRef.current = null;
+    }
+
     if (modeRef.current === "absolute") {
       sendAbsolute(e.clientX, e.clientY);
     }

--- a/src/components/MousePad.tsx
+++ b/src/components/MousePad.tsx
@@ -295,10 +295,12 @@ export default function MousePad(props: MousePadProps) {
     }
 
     const onKeyDown = (e: KeyboardEvent) => {
-      // Alt + ` sends an Escape to the core
+      // Alt + ` sends an Escape to the core (once per press, not on auto-repeat)
       if (e.altKey && e.code === "Backquote") {
         e.preventDefault();
-        sendEscToCore();
+        if (!e.repeat) {
+          sendEscToCore();
+        }
         return;
       }
       // leave Esc to the browser (it exits capture); never forward it

--- a/src/components/MousePad.tsx
+++ b/src/components/MousePad.tsx
@@ -57,6 +57,9 @@ export default function MousePad(props: MousePadProps) {
   // readable synchronously from pointer handlers
   const dragLockRef = useRef<boolean>(false);
   const gestureHeldRef = useRef<boolean>(false);
+  // pressActiveRef is true between pointer down and up (finger/button down);
+  // when false, a pointer move is a hover (mouse over the pad, no button)
+  const pressActiveRef = useRef<boolean>(false);
 
   // keep the latest mode/sensitivity readable from pointer handlers
   const modeRef = useRef<MouseMode>(mode);
@@ -102,6 +105,7 @@ export default function MousePad(props: MousePadProps) {
     }
     dragLockRef.current = false;
     gestureHeldRef.current = false;
+    pressActiveRef.current = false;
     lastTapTimeRef.current = null;
     lastTapPosRef.current = null;
     lastPointRef.current = null;
@@ -165,8 +169,24 @@ export default function MousePad(props: MousePadProps) {
     sendMessage(`mousePos:${x},${y}`);
   };
 
+  // establish a baseline when the pointer enters (e.g. a mouse hovering in) so
+  // the first move doesn't jump; a real press re-baselines in handlePointerDown
+  const handlePointerEnter = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!pressActiveRef.current) {
+      lastPointRef.current = { x: e.clientX, y: e.clientY };
+    }
+  };
+
+  // stop hover tracking when the pointer leaves the pad (a press keeps capture)
+  const handlePointerLeave = () => {
+    if (!pressActiveRef.current) {
+      lastPointRef.current = null;
+    }
+  };
+
   const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     e.currentTarget.setPointerCapture(e.pointerId);
+    pressActiveRef.current = true;
     lastPointRef.current = { x: e.clientX, y: e.clientY };
     movedRef.current = 0;
     downTimeRef.current = e.timeStamp;
@@ -190,37 +210,40 @@ export default function MousePad(props: MousePadProps) {
 
   const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
     const last = lastPointRef.current;
+    lastPointRef.current = { x: e.clientX, y: e.clientY };
     if (!last) {
+      // first sample after entering/leaving: just set the baseline
       return;
     }
 
     const rawDx = e.clientX - last.x;
     const rawDy = e.clientY - last.y;
-    movedRef.current += Math.abs(rawDx) + Math.abs(rawDy);
 
-    // moving before the long-press fires means this is an ordinary move/drag,
-    // not a press-and-hold, so cancel the pending hold (both modes)
-    if (holdTimerRef.current !== null && movedRef.current >= tapThreshold) {
-      clearHoldTimer();
+    // tap / long-press bookkeeping only applies while actually pressing; a
+    // hover move (mouse over the pad, no button) just moves the cursor
+    if (pressActiveRef.current) {
+      movedRef.current += Math.abs(rawDx) + Math.abs(rawDy);
+      if (holdTimerRef.current !== null && movedRef.current >= tapThreshold) {
+        clearHoldTimer();
+      }
     }
 
     if (modeRef.current === "absolute") {
       sendAbsolute(e.clientX, e.clientY);
-      lastPointRef.current = { x: e.clientX, y: e.clientY };
       return;
     }
 
     pendingRef.current.dx += rawDx * sensitivityRef.current;
     pendingRef.current.dy += rawDy * sensitivityRef.current;
-    lastPointRef.current = { x: e.clientX, y: e.clientY };
     scheduleFlush();
   };
 
   const handlePointerEnd = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (lastPointRef.current === null) {
+    if (!pressActiveRef.current) {
       return;
     }
-    lastPointRef.current = null;
+    pressActiveRef.current = false;
+    // keep lastPointRef so a hovering mouse keeps moving the cursor after a click
 
     clearHoldTimer();
 
@@ -302,12 +325,12 @@ export default function MousePad(props: MousePadProps) {
   let padHint: string;
   if (held) {
     padHint = dragLock
-      ? "Left button held — drag to move, then tap Release"
-      : "Left button held — drag to move, lift to release";
+      ? "Left button held — move to drag, then tap Release"
+      : "Left button held — move to drag, lift to release";
   } else if (mode === "absolute") {
-    padHint = "Drag to position · tap to click · press & hold to drag";
+    padHint = "Move over the pad to position · tap to click";
   } else {
-    padHint = "Tap = click · double-tap = double-click · press & hold = drag";
+    padHint = "Move over the pad to move · tap = click · hold = drag";
   }
 
   return (
@@ -332,6 +355,8 @@ export default function MousePad(props: MousePadProps) {
 
           <Box
             ref={padRef}
+            onPointerEnter={handlePointerEnter}
+            onPointerLeave={handlePointerLeave}
             onPointerDown={handlePointerDown}
             onPointerMove={handlePointerMove}
             onPointerUp={handlePointerEnd}

--- a/src/components/MousePad.tsx
+++ b/src/components/MousePad.tsx
@@ -11,8 +11,7 @@ import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 
-import { ControlApi } from "../lib/api";
-import { MouseButtons, ScreenResponse } from "../lib/models";
+import { MouseButtons } from "../lib/models";
 
 type MouseMode = "relative" | "absolute";
 
@@ -20,6 +19,10 @@ type MouseMode = "relative" | "absolute";
 const tapThreshold = 10;
 // maximum duration (ms) of a tap
 const tapDuration = 300;
+// max time (ms) between two taps to register as a double-tap
+const doubleTapWindow = 250;
+// max distance (px) between two taps to register as a double-tap
+const doubleTapDist = 24;
 
 interface MousePadProps {
   open: boolean;
@@ -32,8 +35,6 @@ export default function MousePad(props: MousePadProps) {
 
   const [mode, setMode] = useState<MouseMode>("relative");
   const [sensitivity, setSensitivity] = useState<number>(1.5);
-  const [screen, setScreen] = useState<ScreenResponse | null>(null);
-  const [screenError, setScreenError] = useState<boolean>(false);
 
   const padRef = useRef<HTMLDivElement | null>(null);
   const lastPointRef = useRef<{ x: number; y: number } | null>(null);
@@ -41,6 +42,9 @@ export default function MousePad(props: MousePadProps) {
   const downTimeRef = useRef<number>(0);
   const pendingRef = useRef<{ dx: number; dy: number }>({ dx: 0, dy: 0 });
   const rafRef = useRef<number | null>(null);
+  const lastTapTimeRef = useRef<number | null>(null);
+  const lastTapPosRef = useRef<{ x: number; y: number } | null>(null);
+  const clickTimerRef = useRef<number | null>(null);
 
   // keep the latest mode/sensitivity readable from pointer handlers
   const modeRef = useRef<MouseMode>(mode);
@@ -52,40 +56,20 @@ export default function MousePad(props: MousePadProps) {
     sensitivityRef.current = sensitivity;
   }, [sensitivity]);
 
-  // the screen resolution is needed to map the pad onto absolute coordinates
+  // cancel any queued movement frame and pending tap when the dialog closes
   useEffect(() => {
     if (!open) {
-      return;
-    }
-
-    let cancelled = false;
-    const api = new ControlApi();
-    api
-      .getScreen()
-      .then((res) => {
-        if (!cancelled) {
-          setScreen(res);
-          setScreenError(false);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setScreen(null);
-          setScreenError(true);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [open]);
-
-  // cancel any queued movement frame when the dialog closes
-  useEffect(() => {
-    if (!open && rafRef.current !== null) {
-      window.cancelAnimationFrame(rafRef.current);
-      rafRef.current = null;
-      pendingRef.current = { dx: 0, dy: 0 };
+      if (rafRef.current !== null) {
+        window.cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+        pendingRef.current = { dx: 0, dy: 0 };
+      }
+      if (clickTimerRef.current !== null) {
+        window.clearTimeout(clickTimerRef.current);
+        clickTimerRef.current = null;
+      }
+      lastTapTimeRef.current = null;
+      lastTapPosRef.current = null;
     }
   }, [open]);
 
@@ -108,7 +92,7 @@ export default function MousePad(props: MousePadProps) {
 
   const sendAbsolute = (clientX: number, clientY: number) => {
     const pad = padRef.current;
-    if (!pad || !screen) {
+    if (!pad) {
       return;
     }
 
@@ -122,8 +106,10 @@ export default function MousePad(props: MousePadProps) {
     fx = Math.min(1, Math.max(0, fx));
     fy = Math.min(1, Math.max(0, fy));
 
-    const x = Math.round(fx * (screen.width - 1));
-    const y = Math.round(fy * (screen.height - 1));
+    // send position as per-mille (0-1000) of the screen; the server maps it
+    // onto the pointer range, so it's independent of the video resolution
+    const x = Math.round(fx * 1000);
+    const y = Math.round(fy * 1000);
     sendMessage(`mousePos:${x},${y}`);
   };
 
@@ -167,10 +153,38 @@ export default function MousePad(props: MousePadProps) {
     const duration = e.timeStamp - downTimeRef.current;
     const wasTap = movedRef.current < tapThreshold && duration < tapDuration;
     lastPointRef.current = null;
+    if (!wasTap) {
+      return;
+    }
 
-    // a quick tap in trackpad mode acts as a left click
-    if (wasTap && modeRef.current === "relative") {
-      sendMessage("mouseBtn:click");
+    // a quick tap acts as a left click; two quick taps as a double click,
+    // in both trackpad and absolute modes
+    const pos = { x: e.clientX, y: e.clientY };
+    const prevTime = lastTapTimeRef.current;
+    const prevPos = lastTapPosRef.current;
+    const isDoubleTap =
+      prevTime !== null &&
+      prevPos !== null &&
+      e.timeStamp - prevTime < doubleTapWindow &&
+      Math.abs(pos.x - prevPos.x) + Math.abs(pos.y - prevPos.y) < doubleTapDist;
+
+    if (clickTimerRef.current !== null) {
+      window.clearTimeout(clickTimerRef.current);
+      clickTimerRef.current = null;
+    }
+
+    if (isDoubleTap) {
+      lastTapTimeRef.current = null;
+      lastTapPosRef.current = null;
+      sendMessage("mouseBtn:double_click");
+    } else {
+      // defer the single click briefly so a following tap can upgrade it
+      lastTapTimeRef.current = e.timeStamp;
+      lastTapPosRef.current = pos;
+      clickTimerRef.current = window.setTimeout(() => {
+        clickTimerRef.current = null;
+        sendMessage("mouseBtn:click");
+      }, doubleTapWindow);
     }
   };
 
@@ -185,18 +199,10 @@ export default function MousePad(props: MousePadProps) {
     { label: "Middle Click", button: "middle" },
   ];
 
-  let padHint: string;
-  if (mode === "absolute") {
-    if (screenError) {
-      padHint = "Screen resolution unavailable";
-    } else if (screen) {
-      padHint = `Tap or drag to position · ${screen.width}×${screen.height}`;
-    } else {
-      padHint = "Reading screen resolution…";
-    }
-  } else {
-    padHint = "Drag to move · tap to click";
-  }
+  const padHint =
+    mode === "absolute"
+      ? "Drag to position · tap/double-tap to click"
+      : "Drag to move · tap to click · double-tap to double-click";
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth>

--- a/src/components/MousePad.tsx
+++ b/src/components/MousePad.tsx
@@ -1,0 +1,290 @@
+import React, { useEffect, useRef, useState } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Grid from "@mui/material/Grid";
+import Slider from "@mui/material/Slider";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+
+import { ControlApi } from "../lib/api";
+import { MouseButtons, ScreenResponse } from "../lib/models";
+
+type MouseMode = "relative" | "absolute";
+
+// movement (in CSS pixels) below which a press/release is treated as a tap
+const tapThreshold = 10;
+// maximum duration (ms) of a tap
+const tapDuration = 300;
+
+interface MousePadProps {
+  open: boolean;
+  onClose: () => void;
+  sendMessage: (message: string) => void;
+}
+
+export default function MousePad(props: MousePadProps) {
+  const { open, onClose, sendMessage } = props;
+
+  const [mode, setMode] = useState<MouseMode>("relative");
+  const [sensitivity, setSensitivity] = useState<number>(1.5);
+  const [screen, setScreen] = useState<ScreenResponse | null>(null);
+  const [screenError, setScreenError] = useState<boolean>(false);
+
+  const padRef = useRef<HTMLDivElement | null>(null);
+  const lastPointRef = useRef<{ x: number; y: number } | null>(null);
+  const movedRef = useRef<number>(0);
+  const downTimeRef = useRef<number>(0);
+  const pendingRef = useRef<{ dx: number; dy: number }>({ dx: 0, dy: 0 });
+  const rafRef = useRef<number | null>(null);
+
+  // keep the latest mode/sensitivity readable from pointer handlers
+  const modeRef = useRef<MouseMode>(mode);
+  const sensitivityRef = useRef<number>(sensitivity);
+  useEffect(() => {
+    modeRef.current = mode;
+  }, [mode]);
+  useEffect(() => {
+    sensitivityRef.current = sensitivity;
+  }, [sensitivity]);
+
+  // the screen resolution is needed to map the pad onto absolute coordinates
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    let cancelled = false;
+    const api = new ControlApi();
+    api
+      .getScreen()
+      .then((res) => {
+        if (!cancelled) {
+          setScreen(res);
+          setScreenError(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setScreen(null);
+          setScreenError(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  // cancel any queued movement frame when the dialog closes
+  useEffect(() => {
+    if (!open && rafRef.current !== null) {
+      window.cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+      pendingRef.current = { dx: 0, dy: 0 };
+    }
+  }, [open]);
+
+  const flushMove = () => {
+    rafRef.current = null;
+    const { dx, dy } = pendingRef.current;
+    pendingRef.current = { dx: 0, dy: 0 };
+    const rx = Math.round(dx);
+    const ry = Math.round(dy);
+    if (rx !== 0 || ry !== 0) {
+      sendMessage(`mouseMove:${rx},${ry}`);
+    }
+  };
+
+  const scheduleFlush = () => {
+    if (rafRef.current === null) {
+      rafRef.current = window.requestAnimationFrame(flushMove);
+    }
+  };
+
+  const sendAbsolute = (clientX: number, clientY: number) => {
+    const pad = padRef.current;
+    if (!pad || !screen) {
+      return;
+    }
+
+    const rect = pad.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      return;
+    }
+
+    let fx = (clientX - rect.left) / rect.width;
+    let fy = (clientY - rect.top) / rect.height;
+    fx = Math.min(1, Math.max(0, fx));
+    fy = Math.min(1, Math.max(0, fy));
+
+    const x = Math.round(fx * (screen.width - 1));
+    const y = Math.round(fy * (screen.height - 1));
+    sendMessage(`mousePos:${x},${y}`);
+  };
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    lastPointRef.current = { x: e.clientX, y: e.clientY };
+    movedRef.current = 0;
+    downTimeRef.current = e.timeStamp;
+
+    if (modeRef.current === "absolute") {
+      sendAbsolute(e.clientX, e.clientY);
+    }
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const last = lastPointRef.current;
+    if (!last) {
+      return;
+    }
+
+    if (modeRef.current === "absolute") {
+      sendAbsolute(e.clientX, e.clientY);
+      lastPointRef.current = { x: e.clientX, y: e.clientY };
+      return;
+    }
+
+    const rawDx = e.clientX - last.x;
+    const rawDy = e.clientY - last.y;
+    movedRef.current += Math.abs(rawDx) + Math.abs(rawDy);
+    pendingRef.current.dx += rawDx * sensitivityRef.current;
+    pendingRef.current.dy += rawDy * sensitivityRef.current;
+    lastPointRef.current = { x: e.clientX, y: e.clientY };
+    scheduleFlush();
+  };
+
+  const handlePointerEnd = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (lastPointRef.current === null) {
+      return;
+    }
+
+    const duration = e.timeStamp - downTimeRef.current;
+    const wasTap = movedRef.current < tapThreshold && duration < tapDuration;
+    lastPointRef.current = null;
+
+    // a quick tap in trackpad mode acts as a left click
+    if (wasTap && modeRef.current === "relative") {
+      sendMessage("mouseBtn:click");
+    }
+  };
+
+  const clickButton = (button: MouseButtons) => {
+    sendMessage(`mouseBtn:${button}`);
+  };
+
+  const buttons: { label: string; button: MouseButtons }[] = [
+    { label: "Left Click", button: "click" },
+    { label: "Double Click", button: "double_click" },
+    { label: "Right Click", button: "right" },
+    { label: "Middle Click", button: "middle" },
+  ];
+
+  let padHint: string;
+  if (mode === "absolute") {
+    if (screenError) {
+      padHint = "Screen resolution unavailable";
+    } else if (screen) {
+      padHint = `Tap or drag to position · ${screen.width}×${screen.height}`;
+    } else {
+      padHint = "Reading screen resolution…";
+    }
+  } else {
+    padHint = "Drag to move · tap to click";
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth>
+      <DialogContent>
+        <Stack spacing={2}>
+          <ToggleButtonGroup
+            color="primary"
+            value={mode}
+            exclusive
+            fullWidth
+            size="small"
+            onChange={(_, value) => {
+              if (value !== null) {
+                setMode(value as MouseMode);
+              }
+            }}
+          >
+            <ToggleButton value="relative">Trackpad</ToggleButton>
+            <ToggleButton value="absolute">Absolute</ToggleButton>
+          </ToggleButtonGroup>
+
+          <Box
+            ref={padRef}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerEnd}
+            onPointerCancel={handlePointerEnd}
+            sx={{
+              height: "40vh",
+              minHeight: 200,
+              border: 1,
+              borderColor: "divider",
+              borderRadius: 2,
+              bgcolor: "action.hover",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              textAlign: "center",
+              px: 2,
+              touchAction: "none",
+              userSelect: "none",
+              cursor: mode === "absolute" ? "crosshair" : "move",
+            }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              {padHint}
+            </Typography>
+          </Box>
+
+          {mode === "relative" && (
+            <Box sx={{ px: 1 }}>
+              <Typography variant="caption" color="text.secondary">
+                Sensitivity
+              </Typography>
+              <Slider
+                value={sensitivity}
+                min={0.5}
+                max={4}
+                step={0.1}
+                marks={[
+                  { value: 0.5, label: "0.5×" },
+                  { value: 4, label: "4×" },
+                ]}
+                valueLabelDisplay="auto"
+                valueLabelFormat={(v) => `${v}×`}
+                onChange={(_, value) => setSensitivity(value as number)}
+              />
+            </Box>
+          )}
+
+          <Grid container spacing={1}>
+            {buttons.map((b) => (
+              <Grid item xs={6} key={b.button}>
+                <Button
+                  variant="outlined"
+                  sx={{ width: "100%" }}
+                  onClick={() => clickButton(b.button)}
+                >
+                  {b.label}
+                </Button>
+              </Grid>
+            ))}
+          </Grid>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/MousePad.tsx
+++ b/src/components/MousePad.tsx
@@ -11,6 +11,7 @@ import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import PanToolIcon from "@mui/icons-material/PanTool";
+import LockIcon from "@mui/icons-material/Lock";
 
 import { MouseButtons } from "../lib/models";
 
@@ -27,6 +28,14 @@ const doubleTapDist = 24;
 // how long to hold still before a press becomes a click-and-hold drag
 const holdToDragDelay = 400;
 
+// map a DOM mouse button number to its name
+function buttonName(button: number): string | null {
+  if (button === 0) return "left";
+  if (button === 1) return "middle";
+  if (button === 2) return "right";
+  return null;
+}
+
 interface MousePadProps {
   open: boolean;
   onClose: () => void;
@@ -42,6 +51,16 @@ export default function MousePad(props: MousePadProps) {
   const [dragLock, setDragLock] = useState<boolean>(false);
   // held: left button currently down by any means (lock or long-press gesture)
   const [held, setHeld] = useState<boolean>(false);
+  // captured: pointer lock is active (desktop mouse capture)
+  const [captured, setCaptured] = useState<boolean>(false);
+  // whether the browser supports pointer lock at all
+  const [canCapture] = useState<boolean>(
+    () =>
+      typeof document !== "undefined" &&
+      "pointerLockElement" in document &&
+      typeof HTMLElement !== "undefined" &&
+      "requestPointerLock" in HTMLElement.prototype
+  );
 
   const padRef = useRef<HTMLDivElement | null>(null);
   const lastPointRef = useRef<{ x: number; y: number } | null>(null);
@@ -60,6 +79,10 @@ export default function MousePad(props: MousePadProps) {
   // pressActiveRef is true between pointer down and up (finger/button down);
   // when false, a pointer move is a hover (mouse over the pad, no button)
   const pressActiveRef = useRef<boolean>(false);
+  // pointer-lock state readable from handlers, and the physical buttons held
+  // down while captured (so we can release them if the lock is lost)
+  const capturedRef = useRef<boolean>(false);
+  const heldButtonsRef = useRef<Set<number>>(new Set());
 
   // keep the latest mode/sensitivity readable from pointer handlers
   const modeRef = useRef<MouseMode>(mode);
@@ -88,6 +111,17 @@ export default function MousePad(props: MousePadProps) {
     }
   };
 
+  // release any physical buttons passed through while captured
+  const releasePassthrough = () => {
+    heldButtonsRef.current.forEach((b) => {
+      const name = buttonName(b);
+      if (name) {
+        sendRef.current(`mouseBtn:${name}_up`);
+      }
+    });
+    heldButtonsRef.current.clear();
+  };
+
   // release any held button and reset transient state
   const releaseAll = () => {
     clearHoldTimer();
@@ -103,9 +137,14 @@ export default function MousePad(props: MousePadProps) {
     if (dragLockRef.current || gestureHeldRef.current) {
       sendRef.current("mouseBtn:left_up");
     }
+    releasePassthrough();
+    if (typeof document !== "undefined" && document.pointerLockElement) {
+      document.exitPointerLock();
+    }
     dragLockRef.current = false;
     gestureHeldRef.current = false;
     pressActiveRef.current = false;
+    capturedRef.current = false;
     lastTapTimeRef.current = null;
     lastTapPosRef.current = null;
     lastPointRef.current = null;
@@ -117,6 +156,7 @@ export default function MousePad(props: MousePadProps) {
       releaseAll();
       setDragLock(false);
       setHeld(false);
+      setCaptured(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
@@ -128,6 +168,65 @@ export default function MousePad(props: MousePadProps) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // track pointer-lock engage/release (Esc releases it via the browser)
+  useEffect(() => {
+    const onChange = () => {
+      const locked =
+        typeof document !== "undefined" &&
+        document.pointerLockElement === padRef.current;
+      capturedRef.current = locked;
+      setCaptured(locked);
+      if (!locked) {
+        releasePassthrough();
+      }
+    };
+    document.addEventListener("pointerlockchange", onChange);
+    return () => document.removeEventListener("pointerlockchange", onChange);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // while captured, pass the physical mouse straight through: relative movement
+  // and raw button down/up, so clicks, double-clicks and drags all behave like
+  // a real mouse
+  useEffect(() => {
+    if (!captured) {
+      return;
+    }
+
+    const onMove = (e: MouseEvent) => {
+      pendingRef.current.dx += e.movementX * sensitivityRef.current;
+      pendingRef.current.dy += e.movementY * sensitivityRef.current;
+      scheduleFlush();
+    };
+    const onDown = (e: MouseEvent) => {
+      const name = buttonName(e.button);
+      if (!name) return;
+      e.preventDefault();
+      heldButtonsRef.current.add(e.button);
+      sendRef.current(`mouseBtn:${name}_down`);
+    };
+    const onUp = (e: MouseEvent) => {
+      const name = buttonName(e.button);
+      if (!name) return;
+      e.preventDefault();
+      heldButtonsRef.current.delete(e.button);
+      sendRef.current(`mouseBtn:${name}_up`);
+    };
+    const onContext = (e: Event) => e.preventDefault();
+
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("mouseup", onUp);
+    document.addEventListener("contextmenu", onContext);
+    return () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("mouseup", onUp);
+      document.removeEventListener("contextmenu", onContext);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [captured]);
 
   const flushMove = () => {
     rafRef.current = null;
@@ -143,6 +242,21 @@ export default function MousePad(props: MousePadProps) {
   const scheduleFlush = () => {
     if (rafRef.current === null) {
       rafRef.current = window.requestAnimationFrame(flushMove);
+    }
+  };
+
+  const requestCapture = () => {
+    const pad = padRef.current;
+    if (!pad || typeof pad.requestPointerLock !== "function") {
+      return;
+    }
+    const req = pad.requestPointerLock() as unknown as
+      | Promise<void>
+      | undefined;
+    if (req && typeof req.catch === "function") {
+      req.catch(() => {
+        /* lock can fail if not from a user gesture; ignore */
+      });
     }
   };
 
@@ -172,6 +286,7 @@ export default function MousePad(props: MousePadProps) {
   // establish a baseline when the pointer enters (e.g. a mouse hovering in) so
   // the first move doesn't jump; a real press re-baselines in handlePointerDown
   const handlePointerEnter = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (capturedRef.current) return;
     if (!pressActiveRef.current) {
       lastPointRef.current = { x: e.clientX, y: e.clientY };
     }
@@ -179,12 +294,14 @@ export default function MousePad(props: MousePadProps) {
 
   // stop hover tracking when the pointer leaves the pad (a press keeps capture)
   const handlePointerLeave = () => {
+    if (capturedRef.current) return;
     if (!pressActiveRef.current) {
       lastPointRef.current = null;
     }
   };
 
   const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (capturedRef.current) return;
     e.currentTarget.setPointerCapture(e.pointerId);
     pressActiveRef.current = true;
     lastPointRef.current = { x: e.clientX, y: e.clientY };
@@ -209,6 +326,7 @@ export default function MousePad(props: MousePadProps) {
   };
 
   const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (capturedRef.current) return;
     const last = lastPointRef.current;
     lastPointRef.current = { x: e.clientX, y: e.clientY };
     if (!last) {
@@ -239,6 +357,7 @@ export default function MousePad(props: MousePadProps) {
   };
 
   const handlePointerEnd = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (capturedRef.current) return;
     if (!pressActiveRef.current) {
       return;
     }
@@ -333,8 +452,21 @@ export default function MousePad(props: MousePadProps) {
     padHint = "Move over the pad to move · tap = click · hold = drag";
   }
 
+  const padActive = held || captured;
+
   return (
-    <Dialog open={open} onClose={onClose} fullWidth>
+    <Dialog
+      open={open}
+      onClose={(_, reason) => {
+        // while the mouse is captured, Esc releases the pointer lock — don't
+        // let it also close the dialog
+        if (reason === "escapeKeyDown" && capturedRef.current) {
+          return;
+        }
+        onClose();
+      }}
+      fullWidth
+    >
       <DialogContent>
         <Stack spacing={2}>
           <ToggleButtonGroup
@@ -343,6 +475,7 @@ export default function MousePad(props: MousePadProps) {
             exclusive
             fullWidth
             size="small"
+            disabled={captured}
             onChange={(_, value) => {
               if (value !== null) {
                 setMode(value as MouseMode);
@@ -364,24 +497,52 @@ export default function MousePad(props: MousePadProps) {
             sx={{
               height: "40vh",
               minHeight: 200,
-              border: held ? 2 : 1,
-              borderColor: held ? "primary.main" : "divider",
+              border: padActive ? 2 : 1,
+              borderColor: padActive ? "primary.main" : "divider",
               borderRadius: 2,
-              bgcolor: held ? "action.selected" : "action.hover",
+              bgcolor: padActive ? "action.selected" : "action.hover",
               display: "flex",
+              flexDirection: "column",
+              gap: 1,
               alignItems: "center",
               justifyContent: "center",
               textAlign: "center",
               px: 2,
               touchAction: "none",
               userSelect: "none",
-              cursor: mode === "absolute" ? "crosshair" : "move",
+              cursor: captured ? "none" : mode === "absolute" ? "crosshair" : "move",
             }}
           >
-            <Typography variant="body2" color="text.secondary">
-              {padHint}
-            </Typography>
+            {captured ? (
+              <>
+                <LockIcon color="primary" />
+                <Typography variant="subtitle1">Mouse captured</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Move the mouse to move the cursor. Left, right and middle
+                  clicks and dragging all work like a real mouse.
+                </Typography>
+                <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                  Press Esc to release
+                </Typography>
+              </>
+            ) : (
+              <Typography variant="body2" color="text.secondary">
+                {padHint}
+              </Typography>
+            )}
           </Box>
+
+          {canCapture && mode === "relative" && (
+            <Button
+              variant="outlined"
+              sx={{ width: "100%" }}
+              startIcon={<LockIcon />}
+              disabled={captured}
+              onClick={requestCapture}
+            >
+              {captured ? "Captured — press Esc to release" : "Capture Mouse"}
+            </Button>
+          )}
 
           {mode === "relative" && (
             <Box sx={{ px: 1 }}>
@@ -409,6 +570,7 @@ export default function MousePad(props: MousePadProps) {
             color={dragLock ? "warning" : "primary"}
             sx={{ width: "100%" }}
             startIcon={<PanToolIcon />}
+            disabled={captured}
             onClick={toggleDragLock}
           >
             {dragLock ? "Release" : "Click & Hold"}
@@ -420,6 +582,7 @@ export default function MousePad(props: MousePadProps) {
                 <Button
                   variant="outlined"
                   sx={{ width: "100%" }}
+                  disabled={captured}
                   onClick={() => clickButton(b.button)}
                 >
                   {b.label}

--- a/src/components/MousePad.tsx
+++ b/src/components/MousePad.tsx
@@ -36,6 +36,37 @@ function buttonName(button: number): string | null {
   return null;
 }
 
+// map a browser KeyboardEvent.code to its Linux/uinput key code, for forwarding
+// physical keystrokes to the core while captured
+const keyCodeMap: { [code: string]: number } = {
+  Escape: 1,
+  Digit1: 2, Digit2: 3, Digit3: 4, Digit4: 5, Digit5: 6,
+  Digit6: 7, Digit7: 8, Digit8: 9, Digit9: 10, Digit0: 11,
+  Minus: 12, Equal: 13, Backspace: 14, Tab: 15,
+  KeyQ: 16, KeyW: 17, KeyE: 18, KeyR: 19, KeyT: 20, KeyY: 21,
+  KeyU: 22, KeyI: 23, KeyO: 24, KeyP: 25,
+  BracketLeft: 26, BracketRight: 27, Enter: 28, ControlLeft: 29,
+  KeyA: 30, KeyS: 31, KeyD: 32, KeyF: 33, KeyG: 34, KeyH: 35,
+  KeyJ: 36, KeyK: 37, KeyL: 38, Semicolon: 39, Quote: 40,
+  Backquote: 41, ShiftLeft: 42, Backslash: 43,
+  KeyZ: 44, KeyX: 45, KeyC: 46, KeyV: 47, KeyB: 48, KeyN: 49,
+  KeyM: 50, Comma: 51, Period: 52, Slash: 53, ShiftRight: 54,
+  NumpadMultiply: 55, AltLeft: 56, Space: 57, CapsLock: 58,
+  F1: 59, F2: 60, F3: 61, F4: 62, F5: 63, F6: 64, F7: 65,
+  F8: 66, F9: 67, F10: 68, NumLock: 69, ScrollLock: 70,
+  Numpad7: 71, Numpad8: 72, Numpad9: 73, NumpadSubtract: 74,
+  Numpad4: 75, Numpad5: 76, Numpad6: 77, NumpadAdd: 78,
+  Numpad1: 79, Numpad2: 80, Numpad3: 81, Numpad0: 82, NumpadDecimal: 83,
+  F11: 87, F12: 88,
+  NumpadEnter: 96, ControlRight: 97, NumpadDivide: 98, AltRight: 100,
+  Home: 102, ArrowUp: 103, PageUp: 104, ArrowLeft: 105,
+  ArrowRight: 106, End: 107, ArrowDown: 108, PageDown: 109,
+  Insert: 110, Delete: 111, MetaLeft: 125, MetaRight: 126,
+};
+
+// modifier key codes (ctrl/shift/alt/meta), used to send a clean Escape
+const modifierCodes = new Set<number>([29, 42, 54, 56, 97, 100, 125, 126]);
+
 interface MousePadProps {
   open: boolean;
   onClose: () => void;
@@ -83,6 +114,9 @@ export default function MousePad(props: MousePadProps) {
   // down while captured (so we can release them if the lock is lost)
   const capturedRef = useRef<boolean>(false);
   const heldButtonsRef = useRef<Set<number>>(new Set());
+  // key codes currently held down while captured, so they can be released if
+  // capture ends with a key still pressed
+  const pressedKeysRef = useRef<Set<number>>(new Set());
 
   // keep the latest mode/sensitivity readable from pointer handlers
   const modeRef = useRef<MouseMode>(mode);
@@ -122,6 +156,28 @@ export default function MousePad(props: MousePadProps) {
     heldButtonsRef.current.clear();
   };
 
+  // release any keys passed through while captured
+  const releaseKeys = () => {
+    pressedKeysRef.current.forEach((code) => {
+      sendRef.current(`kbdRawUp:${code}`);
+    });
+    pressedKeysRef.current.clear();
+  };
+
+  // send a clean Escape to the core. The physical Esc key can't be used while
+  // pointer-locked (the browser reserves it to exit capture), so this is
+  // triggered by Alt+`. Any held modifiers are lifted around it so the core
+  // sees a bare Escape, then re-pressed.
+  const sendEscToCore = () => {
+    const heldMods = Array.from(pressedKeysRef.current).filter((c) =>
+      modifierCodes.has(c)
+    );
+    heldMods.forEach((c) => sendRef.current(`kbdRawUp:${c}`));
+    sendRef.current("kbdRawDown:1");
+    sendRef.current("kbdRawUp:1");
+    heldMods.forEach((c) => sendRef.current(`kbdRawDown:${c}`));
+  };
+
   // release any held button and reset transient state
   const releaseAll = () => {
     clearHoldTimer();
@@ -138,6 +194,7 @@ export default function MousePad(props: MousePadProps) {
       sendRef.current("mouseBtn:left_up");
     }
     releasePassthrough();
+    releaseKeys();
     if (typeof document !== "undefined" && document.pointerLockElement) {
       document.exitPointerLock();
     }
@@ -179,6 +236,7 @@ export default function MousePad(props: MousePadProps) {
       setCaptured(locked);
       if (!locked) {
         releasePassthrough();
+        releaseKeys();
       }
     };
     document.addEventListener("pointerlockchange", onChange);
@@ -224,6 +282,63 @@ export default function MousePad(props: MousePadProps) {
       document.removeEventListener("mousedown", onDown);
       document.removeEventListener("mouseup", onUp);
       document.removeEventListener("contextmenu", onContext);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [captured]);
+
+  // while captured, forward physical key presses to the core. Plain Esc exits
+  // capture (browser pointer-lock behaviour), so Alt+` is provided to send an
+  // Escape to the core instead.
+  useEffect(() => {
+    if (!captured) {
+      return;
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      // Alt + ` sends an Escape to the core
+      if (e.altKey && e.code === "Backquote") {
+        e.preventDefault();
+        sendEscToCore();
+        return;
+      }
+      // leave Esc to the browser (it exits capture); never forward it
+      if (e.code === "Escape") {
+        return;
+      }
+      const code = keyCodeMap[e.code];
+      if (code === undefined) {
+        return;
+      }
+      e.preventDefault();
+      if (e.repeat) {
+        return;
+      }
+      if (!pressedKeysRef.current.has(code)) {
+        pressedKeysRef.current.add(code);
+        sendRef.current(`kbdRawDown:${code}`);
+      }
+    };
+
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.code === "Escape") {
+        return;
+      }
+      const code = keyCodeMap[e.code];
+      if (code === undefined) {
+        return;
+      }
+      e.preventDefault();
+      if (pressedKeysRef.current.has(code)) {
+        pressedKeysRef.current.delete(code);
+        sendRef.current(`kbdRawUp:${code}`);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    document.addEventListener("keyup", onKeyUp, true);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("keyup", onKeyUp, true);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [captured]);
@@ -523,10 +638,13 @@ export default function MousePad(props: MousePadProps) {
             {captured ? (
               <>
                 <LockIcon color="primary" />
-                <Typography variant="subtitle1">Mouse captured</Typography>
+                <Typography variant="subtitle1">
+                  Mouse &amp; keyboard captured
+                </Typography>
                 <Typography variant="body2" color="text.secondary">
-                  Move the mouse to move the cursor. Left, right and middle
-                  clicks and dragging all work like a real mouse.
+                  Move the mouse and type to control the core. Clicks, dragging
+                  and key presses all pass through like a real mouse and
+                  keyboard. Alt + ` sends an Escape to the core.
                 </Typography>
                 <Typography variant="body2" sx={{ fontWeight: 600 }}>
                   Press Esc to release
@@ -547,7 +665,9 @@ export default function MousePad(props: MousePadProps) {
               disabled={captured}
               onClick={requestCapture}
             >
-              {captured ? "Captured — press Esc to release" : "Capture Mouse"}
+              {captured
+                ? "Captured — press Esc to release"
+                : "Capture Mouse & Keyboard"}
             </Button>
           )}
 

--- a/src/components/MousePad.tsx
+++ b/src/components/MousePad.tsx
@@ -10,6 +10,7 @@ import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
+import PanToolIcon from "@mui/icons-material/PanTool";
 
 import { MouseButtons } from "../lib/models";
 
@@ -23,6 +24,8 @@ const tapDuration = 300;
 const doubleTapWindow = 250;
 // max distance (px) between two taps to register as a double-tap
 const doubleTapDist = 24;
+// how long to hold still before a press becomes a click-and-hold drag
+const holdToDragDelay = 400;
 
 interface MousePadProps {
   open: boolean;
@@ -35,6 +38,10 @@ export default function MousePad(props: MousePadProps) {
 
   const [mode, setMode] = useState<MouseMode>("relative");
   const [sensitivity, setSensitivity] = useState<number>(1.5);
+  // dragLock: left button held down via the Hold button, until toggled off
+  const [dragLock, setDragLock] = useState<boolean>(false);
+  // held: left button currently down by any means (lock or long-press gesture)
+  const [held, setHeld] = useState<boolean>(false);
 
   const padRef = useRef<HTMLDivElement | null>(null);
   const lastPointRef = useRef<{ x: number; y: number } | null>(null);
@@ -45,6 +52,11 @@ export default function MousePad(props: MousePadProps) {
   const lastTapTimeRef = useRef<number | null>(null);
   const lastTapPosRef = useRef<{ x: number; y: number } | null>(null);
   const clickTimerRef = useRef<number | null>(null);
+  const holdTimerRef = useRef<number | null>(null);
+  // dragLockRef / gestureHeldRef mirror the two ways the button can be held,
+  // readable synchronously from pointer handlers
+  const dragLockRef = useRef<boolean>(false);
+  const gestureHeldRef = useRef<boolean>(false);
 
   // keep the latest mode/sensitivity readable from pointer handlers
   const modeRef = useRef<MouseMode>(mode);
@@ -56,22 +68,62 @@ export default function MousePad(props: MousePadProps) {
     sensitivityRef.current = sensitivity;
   }, [sensitivity]);
 
-  // cancel any queued movement frame and pending tap when the dialog closes
+  // always-current sendMessage for use in cleanup closures
+  const sendRef = useRef(sendMessage);
+  useEffect(() => {
+    sendRef.current = sendMessage;
+  }, [sendMessage]);
+
+  const syncHeld = () => {
+    setHeld(dragLockRef.current || gestureHeldRef.current);
+  };
+
+  const clearHoldTimer = () => {
+    if (holdTimerRef.current !== null) {
+      window.clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+  };
+
+  // release any held button and reset transient state
+  const releaseAll = () => {
+    clearHoldTimer();
+    if (rafRef.current !== null) {
+      window.cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+      pendingRef.current = { dx: 0, dy: 0 };
+    }
+    if (clickTimerRef.current !== null) {
+      window.clearTimeout(clickTimerRef.current);
+      clickTimerRef.current = null;
+    }
+    if (dragLockRef.current || gestureHeldRef.current) {
+      sendRef.current("mouseBtn:left_up");
+    }
+    dragLockRef.current = false;
+    gestureHeldRef.current = false;
+    lastTapTimeRef.current = null;
+    lastTapPosRef.current = null;
+    lastPointRef.current = null;
+  };
+
+  // release everything when the dialog closes
   useEffect(() => {
     if (!open) {
-      if (rafRef.current !== null) {
-        window.cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
-        pendingRef.current = { dx: 0, dy: 0 };
-      }
-      if (clickTimerRef.current !== null) {
-        window.clearTimeout(clickTimerRef.current);
-        clickTimerRef.current = null;
-      }
-      lastTapTimeRef.current = null;
-      lastTapPosRef.current = null;
+      releaseAll();
+      setDragLock(false);
+      setHeld(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
+
+  // release everything if the component unmounts while a button is held
+  useEffect(() => {
+    return () => {
+      releaseAll();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const flushMove = () => {
     rafRef.current = null;
@@ -122,6 +174,18 @@ export default function MousePad(props: MousePadProps) {
     if (modeRef.current === "absolute") {
       sendAbsolute(e.clientX, e.clientY);
     }
+
+    // start long-press-to-drag detection (unless the drag-lock already holds
+    // the button down)
+    clearHoldTimer();
+    if (!dragLockRef.current) {
+      holdTimerRef.current = window.setTimeout(() => {
+        holdTimerRef.current = null;
+        gestureHeldRef.current = true;
+        syncHeld();
+        sendMessage("mouseBtn:left_down");
+      }, holdToDragDelay);
+    }
   };
 
   const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -130,15 +194,22 @@ export default function MousePad(props: MousePadProps) {
       return;
     }
 
+    const rawDx = e.clientX - last.x;
+    const rawDy = e.clientY - last.y;
+    movedRef.current += Math.abs(rawDx) + Math.abs(rawDy);
+
+    // moving before the long-press fires means this is an ordinary move/drag,
+    // not a press-and-hold, so cancel the pending hold (both modes)
+    if (holdTimerRef.current !== null && movedRef.current >= tapThreshold) {
+      clearHoldTimer();
+    }
+
     if (modeRef.current === "absolute") {
       sendAbsolute(e.clientX, e.clientY);
       lastPointRef.current = { x: e.clientX, y: e.clientY };
       return;
     }
 
-    const rawDx = e.clientX - last.x;
-    const rawDy = e.clientY - last.y;
-    movedRef.current += Math.abs(rawDx) + Math.abs(rawDy);
     pendingRef.current.dx += rawDx * sensitivityRef.current;
     pendingRef.current.dy += rawDy * sensitivityRef.current;
     lastPointRef.current = { x: e.clientX, y: e.clientY };
@@ -149,16 +220,30 @@ export default function MousePad(props: MousePadProps) {
     if (lastPointRef.current === null) {
       return;
     }
+    lastPointRef.current = null;
+
+    clearHoldTimer();
+
+    // finished a long-press drag: release the button now
+    if (gestureHeldRef.current) {
+      gestureHeldRef.current = false;
+      syncHeld();
+      sendMessage("mouseBtn:left_up");
+      return;
+    }
+
+    // while the drag-lock holds the button, the pad only drags — no clicks
+    if (dragLockRef.current) {
+      return;
+    }
 
     const duration = e.timeStamp - downTimeRef.current;
     const wasTap = movedRef.current < tapThreshold && duration < tapDuration;
-    lastPointRef.current = null;
     if (!wasTap) {
       return;
     }
 
-    // a quick tap acts as a left click; two quick taps as a double click,
-    // in both trackpad and absolute modes
+    // a quick tap acts as a left click; two quick taps as a double click
     const pos = { x: e.clientX, y: e.clientY };
     const prevTime = lastTapTimeRef.current;
     const prevPos = lastTapPosRef.current;
@@ -188,6 +273,21 @@ export default function MousePad(props: MousePadProps) {
     }
   };
 
+  const toggleDragLock = () => {
+    if (dragLockRef.current) {
+      dragLockRef.current = false;
+      setDragLock(false);
+      syncHeld();
+      sendMessage("mouseBtn:left_up");
+    } else {
+      clearHoldTimer();
+      dragLockRef.current = true;
+      setDragLock(true);
+      syncHeld();
+      sendMessage("mouseBtn:left_down");
+    }
+  };
+
   const clickButton = (button: MouseButtons) => {
     sendMessage(`mouseBtn:${button}`);
   };
@@ -199,10 +299,16 @@ export default function MousePad(props: MousePadProps) {
     { label: "Middle Click", button: "middle" },
   ];
 
-  const padHint =
-    mode === "absolute"
-      ? "Drag to position · tap/double-tap to click"
-      : "Drag to move · tap to click · double-tap to double-click";
+  let padHint: string;
+  if (held) {
+    padHint = dragLock
+      ? "Left button held — drag to move, then tap Release"
+      : "Left button held — drag to move, lift to release";
+  } else if (mode === "absolute") {
+    padHint = "Drag to position · tap to click · press & hold to drag";
+  } else {
+    padHint = "Tap = click · double-tap = double-click · press & hold = drag";
+  }
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth>
@@ -233,10 +339,10 @@ export default function MousePad(props: MousePadProps) {
             sx={{
               height: "40vh",
               minHeight: 200,
-              border: 1,
-              borderColor: "divider",
+              border: held ? 2 : 1,
+              borderColor: held ? "primary.main" : "divider",
               borderRadius: 2,
-              bgcolor: "action.hover",
+              bgcolor: held ? "action.selected" : "action.hover",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
@@ -272,6 +378,16 @@ export default function MousePad(props: MousePadProps) {
               />
             </Box>
           )}
+
+          <Button
+            variant={dragLock ? "contained" : "outlined"}
+            color={dragLock ? "warning" : "primary"}
+            sx={{ width: "100%" }}
+            startIcon={<PanToolIcon />}
+            onClick={toggleDragLock}
+          >
+            {dragLock ? "Release" : "Click & Hold"}
+          </Button>
 
           <Grid container spacing={1}>
             {buttons.map((b) => (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,6 +10,8 @@ import {
   ViewMenu,
   CreateLauncherRequest,
   KeyboardCodes,
+  MouseButtons,
+  ScreenResponse,
   ListInisPayload,
   SysInfoResponse,
   PeersResponse,
@@ -177,6 +179,22 @@ export class ControlApi {
 
   async sendRawKeyboard(key: number) {
     await axios.post(`/controls/keyboard-raw/${key}`);
+  }
+
+  async getScreen(): Promise<ScreenResponse> {
+    return (await axios.get<ScreenResponse>(`/controls/screen`)).data;
+  }
+
+  async moveMouse(x: number, y: number) {
+    await axios.post(`/controls/mouse/move`, { x, y });
+  }
+
+  async setMousePosition(x: number, y: number) {
+    await axios.post(`/controls/mouse/position`, { x, y });
+  }
+
+  async sendMouseButton(button: MouseButtons) {
+    await axios.post(`/controls/mouse/${button}`);
   }
 
   // menu

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -108,6 +108,23 @@ export type KeyboardCodes =
   | "exit_console"
   | "computer_osd";
 
+export type MouseButtons =
+  | "click"
+  | "double_click"
+  | "right"
+  | "middle"
+  | "left_down"
+  | "left_up"
+  | "right_down"
+  | "right_up"
+  | "middle_down"
+  | "middle_up";
+
+export interface ScreenResponse {
+  width: number;
+  height: number;
+}
+
 export interface CreateLauncherRequest {
   gamePath: string;
   folder: string;


### PR DESCRIPTION
Adds mouse control to the **Control** page, alongside the existing keyboard controls.

## What's new
A **Mouse** button opens a trackpad dialog with:
- **Trackpad mode** — drag to move the cursor (relative deltas over WebSocket), tap to left-click, with a sensitivity slider.
- **Absolute mode** — tap/drag maps proportionally onto the screen and positions the cursor at that pixel. Uses the resolution from `GET /controls/screen`.
- **Click buttons** — Left, Double, Right, Middle.

## Depends on
New server endpoints in the `mrext` remote service (`/controls/screen`, `/controls/mouse/move`, `/controls/mouse/position`, `/controls/mouse/{button}`) plus WebSocket commands `mouseMove`, `mousePos`, `mouseBtn`. This PR is the client half.

## Files
- `src/components/MousePad.tsx` (new) — the trackpad dialog
- `src/components/Control.tsx` — Mouse button + dialog wiring
- `src/lib/api.ts`, `src/lib/models.ts` — mouse/screen API methods and types

## Notes
Most MiSTer cores read relative PS/2-style mouse movement, so trackpad mode is the reliable path; absolute mode is best-effort per core. Verified with `tsc` and `vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added mouse controls to the control panel, including a dedicated mouse dialog.
  * Supports both relative (trackpad-style) and absolute (0–1000) movement modes.
  * Enables click, double-click, drag, and press-and-hold interactions with pointer capture when available.
  * Added screen size support to improve mouse positioning accuracy.
  * While mouse control is active, keyboard input can be forwarded to the controlled system.

* **Bug Fixes**
  * Improved cleanup when closing the mouse panel or losing pointer capture to prevent stuck button states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

This PR Is part of the same feature as https://github.com/wizzomafizzo/mrext/pull/136